### PR TITLE
updates to informative PDF

### DIFF
--- a/www/home/form.py
+++ b/www/home/form.py
@@ -161,7 +161,7 @@ class PDFInfo:
     jst_course_credits = []
 
     #Used for filling out Courses in review Section of PDF
-    review_courses = []
+    review_courses = {}
 
     #Used for filling out General Elective Credits fo PDF
     elective_courses = []

--- a/www/home/views.py
+++ b/www/home/views.py
@@ -95,12 +95,12 @@ def course_information_pdf_processing(request):
 
         course_codes.sort()
         #data = str(CourseLookup().get_equivalent_courses(course_code)).replace("'", '"').replace("None", "null")
-        accepted_data, elective_data, no_data = CourseLookup().get_equivalent_course_objects(course_codes)
+        accepted_data, nonequivilant_data, no_data = CourseLookup().get_equivalent_course_objects(course_codes)
         equivalent_courses = set()
         jst_course_credits_dict = {}
 
         print("accepted_data is: ", accepted_data)
-        print("elective_data is: ", elective_data)
+        print("nonequivilant_data is: ", nonequivilant_data)
         print("no_data is: ", no_data)
 
             #pulling equivalent oc courses for each Millitary.
@@ -121,7 +121,8 @@ def course_information_pdf_processing(request):
         pdf_info = PDFInfo()
         pdf_info.oc_equivalance = equivalent_courses
         pdf_info.jst_course_credits = jst_course_credits_dict
-        pdf_info.review_courses = no_data
+        #pdf_info.review_courses['no_data'] = no_data
+        pdf_info.review_courses['no_equivilancy'] = nonequivilant_data
         pdf_info.selected_courses = accepted_data
         print(pdf_info)
 

--- a/www/template/pdf_form.html
+++ b/www/template/pdf_form.html
@@ -53,6 +53,7 @@
                                     {#displaying the course number and course name#}
                                     {% if forloop.first %}
                                         <h5>JST: {{Course.CourseNumber}} {{Course.CourseName}}</h5>
+                                        <strong>Description:</strong> {{Course.CourseDescription}}
                                         <div class="equivalent_courses_header">
                                             <h6>Equivalent OC Courses:</h6>
                                         </div>
@@ -94,8 +95,20 @@
                     <tr><td>
                         {% if data.review_courses|length != 0 %}<h5>JST Course Codes:</h5>{% else %}None{% endif %}
                         <div class="equivilent_courses_header">
-                            {% for course in data.review_courses %} {#looping through queryset with selected jst course objects#}
-                                {{course}}{% if not forloop.last %}, {% else %}.{% endif %}
+                            {% for key,value in data.review_courses.items %}
+                                {% if key == 'no_equivilancy' %}
+                                    {% for queryset in value %}
+                                        {% for course in queryset %}
+                                            {{course.CourseNumber}}: {{course.CourseName}}
+                                        {% endfor %}
+                                        {% if not forloop.last %},{% endif %}
+                                    {% endfor %}
+                                {% elif key == 'no_data' %}
+                                    {% for course in value %}
+                                        {{course}}{% if not forloop.last %}, {% else %}.{% endif %}
+                                    {% endfor %}
+                                {% endif %}
+                                .
                             {% endfor %}
                         </div>
                     </td></tr>


### PR DESCRIPTION
Courses in the database with no equivalencies now show up in the pdf with their course name, under courses in review, along with courses that are not in the database. Courses that are not in the database will be unable to display course names unless provided. Accepted JST courses will now show their description. 